### PR TITLE
Restore device invitation check.

### DIFF
--- a/apps/teamwork-app/src/containers/Root.js
+++ b/apps/teamwork-app/src/containers/Root.js
@@ -58,7 +58,11 @@ const Root = ({ config }) => {
             <HashRouter>
               <Switch>
                 <Route exact path={routes.register} component={Registration} />
-                <RequireWallet redirect={routes.register}>
+                <RequireWallet
+                  redirect={routes.register}
+                  // Allow access to the AUTH route if it is for joining an Identity, otherwise require a Wallet.
+                  isRequired={(path = '', query = {}) => !path.startsWith(routes.auth) || !query.identityKey}
+                >
                   <Switch>
                     {SystemRoutes(router)}
                     <Route exact path="/app/:topic?"><Redirect to="/home" /></Route>


### PR DESCRIPTION
I am fully open to ways to make it tidier, but I am not sure why this check was removed, since without it we lose /break the 'Authorize a Device' functionality:

https://github.com/wirelineio/incubator/blob/master/examples/playground/src/containers/Root.js
