### PR TITLE
fix: Upgrade DXOS dependencies

### DIFF
--- a/apps/teamwork-app/package.json
+++ b/apps/teamwork-app/package.json
@@ -32,7 +32,7 @@
     "@dxos/debug": "~1.0.0-beta.75",
     "@dxos/echo-db": "~2.6.19",
     "@dxos/editor-pad": "^1.2.0-alpha.52",
-    "@dxos/messenger-pad": "^1.2.0-alpha.52",
+    "@dxos/messenger-pad": "~1.2.0-alpha.52",
     "@dxos/planner-pad": "^1.2.0-alpha.52",
     "@dxos/random-access-multi-storage": "~1.1.0-beta.8",
     "@dxos/react-appkit": "~2.7.49",

--- a/pads/editor-pad/package.json
+++ b/pads/editor-pad/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@dxos/editor": "~1.0.0-beta.34",
     "@dxos/editor-core": "~1.0.0-beta.34",
-    "@dxos/messenger-pad": "^1.2.0-alpha.52",
+    "@dxos/messenger-pad": "~1.2.0-alpha.52",
     "@dxos/text-model": "~2.6.19",
     "clsx": "^1.1.0",
     "hast-util-to-html": "^7.1.1",

--- a/pads/messenger-pad/package.json
+++ b/pads/messenger-pad/package.json
@@ -15,7 +15,7 @@
     "@dxos/debug": "~1.0.0-beta.75",
     "@dxos/echo-db": "~2.6.19",
     "@dxos/editor": "~1.0.0-beta.34",
-    "@dxos/messenger-model": "^1.2.0-alpha.52",
+    "@dxos/messenger-model": "~1.2.0-alpha.52",
     "@dxos/model-adapter": "~2.6.11-alpha.0",
     "@dxos/react-router": "~2.7.49",
     "@dxos/react-ux": "~2.7.49",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

fix: Upgrade DXOS dependencies (#534)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @dxos/version-check upgrade --scope @dxos --tilde</em></summary>

```Shell
Querying NPM for package manifests...
Done.

The following updates will be applied:

	@dxos/messenger-pad ^1.2.0-alpha.52 -> ~1.2.0-alpha.52
	@dxos/messenger-model ^1.2.0-alpha.52 -> ~1.2.0-alpha.52




Don't forget to run yarn to regenerate the lockfile.
```

### stderr:

```Shell
npx: installed 26 in 7.039s
```

</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.2.1: The platform "linux" is incompatible with this module.
info "fsevents@2.2.1" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 229.49s.
```

### stderr:

```Shell
warning "@dxos/cli-app > ipfs-http-client > native-abort-controller@0.0.3" has unmet peer dependency "abort-controller@*".
warning "lerna > @lerna/version > @lerna/github-client > @octokit/rest > @octokit/plugin-request-log@1.0.2" has unmet peer dependency "@octokit/core@>=3".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/canvas-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "react@^16.13.1".
warning " > @dxos/editor-pad@1.2.0-alpha.52" has unmet peer dependency "react-dom@^16.13.1".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/messenger-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/planner-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/table-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/tasks-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/crypto@1.0.5".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-appkit@*".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "@dxos/react-client@*".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/core@^4.9.0".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "@material-ui/icons@^4.5.1".
warning " > @dxos/testing-pad@1.2.0-alpha.52" has unmet peer dependency "react@*".
warning " > @dxos/messenger-model@1.2.0-alpha.52" has unmet peer dependency "@dxos/model-factory@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/react-appkit@2.7.49" has incorrect peer dependency "react@16.12.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/react-client@2.7.49" has incorrect peer dependency "react@16.12.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/react-router@2.7.49" has incorrect peer dependency "react@16.12.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/react-ux@2.7.49" has incorrect peer dependency "react@16.12.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @material-ui/pickers@3.2.10" has unmet peer dependency "@date-io/core@^1.3.6".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/eslint-plugin@1.0.10" has unmet peer dependency "typescript@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @rollup/plugin-babel@5.2.1" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > babel-plugin-styled-components@1.11.1" has unmet peer dependency "styled-components@>= 2".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @dxos/app-cli@1.0.0-beta.68" has incorrect peer dependency "@dxos/cli@^1.0.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/react@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @testing-library/react@11.1.2" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/editor-pad > @dxos/editor@1.0.0-beta.34" has unmet peer dependency "@material-ui/core@^4.11.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/editor-pad > @dxos/editor@1.0.0-beta.34" has unmet peer dependency "@material-ui/icons@^4.9.1".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/editor-pad > rollup-plugin-external-globals@0.5.0" has incorrect peer dependency "rollup@^1.27.9".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/messenger-pad > @testing-library/react-hooks@3.4.2" has unmet peer dependency "react@>=16.9.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/messenger-pad > react-test-renderer@17.0.1" has unmet peer dependency "react@17.0.1".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/planner-pad > react-beautiful-dnd@13.0.0" has unmet peer dependency "react@^16.8.5".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/planner-pad > @rollup/plugin-commonjs@13.0.2" has unmet peer dependency "rollup@^2.3.4".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/table-pad > react-virtualized@9.22.2" has unmet peer dependency "react@^15.3.0 || ^16.0.0-alpha".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/table-pad > react-virtualized@9.22.2" has unmet peer dependency "react-dom@^15.3.0 || ^16.0.0-alpha".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @rollup/plugin-babel > @rollup/pluginutils@3.1.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/addons@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/api@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/client-api@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/components@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/theming@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > react-select@3.1.0" has unmet peer dependency "react-dom@^16.8.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/react > @storybook/core@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/react > react-docgen-typescript-plugin@0.5.2" has unmet peer dependency "typescript@>= 3.x".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/editor-pad > @dxos/editor > prosemirror-utils@0.9.6" has incorrect peer dependency "prosemirror-tables@^0.9.1".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/messenger-pad > react-test-renderer > react-shallow-renderer@16.14.1" has unmet peer dependency "react@^16.0.0 || ^17.0.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/planner-pad > react-beautiful-dnd > react-redux@7.2.2" has unmet peer dependency "react@^16.8.3 || ^17".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/planner-pad > react-beautiful-dnd > use-memo-one@1.1.1" has unmet peer dependency "react@^16.8.0".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/botkit-client > @dxos/network-manager > isomorphic-ws@4.0.1" has unmet peer dependency "ws@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/react-client > @dxos/client > jsondown@1.0.0" has unmet peer dependency "abstract-leveldown@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/teamwork > @dxos/eslint-plugin > @typescript-eslint/eslint-plugin > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/addons > @storybook/router@6.0.28" has unmet peer dependency "react-dom@*".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/addon-knobs > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/react > react-docgen-typescript-plugin > react-docgen-typescript@1.20.5" has unmet peer dependency "typescript@>= 3.x".
warning "workspace-aggregator-1c471f1f-e9a2-448e-a5cb-47f16a46d547 > @dxos/canvas-pad > @storybook/react > react-docgen-typescript-plugin > react-docgen-typescript-loader@3.7.2" has unmet peer dependency "typescript@*".
warning "wrtc@0.4.6" is missing a bundled dependency "node-pre-gyp". This should be reported to the package maintainer.
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- apps/teamwork-app/package.json
- pads/editor-pad/package.json
- pads/messenger-pad/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)